### PR TITLE
feat: Books create기능 추가 및 h2호환성 문제로 인한 엔티티 필드타입 변경

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/shop/nuribooks/books/controller/GlobalExceptionHandler.java
+++ b/src/main/java/shop/nuribooks/books/controller/GlobalExceptionHandler.java
@@ -2,12 +2,14 @@ package shop.nuribooks.books.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 
 import shop.nuribooks.books.dto.errordto.response.ErrorResponseDto;
 import shop.nuribooks.books.exception.BadRequestException;
+import shop.nuribooks.books.exception.DuplicateException;
 import shop.nuribooks.books.exception.ResourceNotFoundException;
 
 @RestControllerAdvice
@@ -30,6 +32,16 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(BadRequestException.class)
 	public ResponseEntity<ErrorResponseDto> handleInvalidDataException(BadRequestException ex, WebRequest request) {
 		return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponseDto> handleValidationException(MethodArgumentNotValidException ex, WebRequest request) {
+		return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+	}
+
+	@ExceptionHandler(DuplicateException.class)
+	public ResponseEntity<ErrorResponseDto> handleDuplicateException(DuplicateException ex, WebRequest request){
+		return buildErrorResponse(HttpStatus.CONFLICT, ex.getMessage(), request);
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/src/main/java/shop/nuribooks/books/controller/books/BooksController.java
+++ b/src/main/java/shop/nuribooks/books/controller/books/BooksController.java
@@ -1,0 +1,36 @@
+package shop.nuribooks.books.controller.books;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import shop.nuribooks.books.dto.books.BooksRegisterReqDto;
+import shop.nuribooks.books.dto.books.BooksRegisterResDto;
+import shop.nuribooks.books.service.books.BooksService;
+
+@RequestMapping("/api/books")
+@RequiredArgsConstructor
+@RestController
+public class BooksController {
+	private final BooksService booksService;
+
+	@Operation(summary = "Register a new book", description = "This endpoint allows administrators to register a new book in the system.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "201", description = "Book registration successful"),
+		@ApiResponse(responseCode = "400", description = "Invalid request data"),
+		@ApiResponse(responseCode = "404", description = "Book state or publisher not found")
+	})
+	@PostMapping
+	public ResponseEntity<BooksRegisterResDto> registerBooks(@Validated @RequestBody BooksRegisterReqDto reqDto){
+		BooksRegisterResDto resDto = booksService.registerBook(reqDto);
+		return ResponseEntity.status(HttpStatus.CREATED).body(resDto);
+	}
+}

--- a/src/main/java/shop/nuribooks/books/controller/books/BooksController.java
+++ b/src/main/java/shop/nuribooks/books/controller/books/BooksController.java
@@ -27,7 +27,8 @@ public class BooksController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "201", description = "Book registration successful"),
 		@ApiResponse(responseCode = "400", description = "Invalid request data"),
-		@ApiResponse(responseCode = "404", description = "Book state or publisher not found")
+		@ApiResponse(responseCode = "404", description = "Book state or publisher not found"),
+		@ApiResponse(responseCode = "409", description = "ISBN already exists"),
 	})
 	@PostMapping
 	public ResponseEntity<BooksRegisterResDto> registerBooks(@Valid @RequestBody BooksRegisterReqDto reqDto){

--- a/src/main/java/shop/nuribooks/books/controller/books/BooksController.java
+++ b/src/main/java/shop/nuribooks/books/controller/books/BooksController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import shop.nuribooks.books.dto.books.BooksRegisterReqDto;
 import shop.nuribooks.books.dto.books.BooksRegisterResDto;
@@ -29,7 +30,7 @@ public class BooksController {
 		@ApiResponse(responseCode = "404", description = "Book state or publisher not found")
 	})
 	@PostMapping
-	public ResponseEntity<BooksRegisterResDto> registerBooks(@Validated @RequestBody BooksRegisterReqDto reqDto){
+	public ResponseEntity<BooksRegisterResDto> registerBooks(@Valid @RequestBody BooksRegisterReqDto reqDto){
 		BooksRegisterResDto resDto = booksService.registerBook(reqDto);
 		return ResponseEntity.status(HttpStatus.CREATED).body(resDto);
 	}

--- a/src/main/java/shop/nuribooks/books/dto/books/BooksRegisterReqDto.java
+++ b/src/main/java/shop/nuribooks/books/dto/books/BooksRegisterReqDto.java
@@ -3,6 +3,8 @@ package shop.nuribooks.books.dto.books;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -38,7 +40,8 @@ public class BooksRegisterReqDto {
 	private BigDecimal price;
 
 	@NotNull
-	@PositiveOrZero
+	@Min(0)
+	@Max(100)
 	private int discountRate;
 
 	@NotBlank
@@ -53,5 +56,6 @@ public class BooksRegisterReqDto {
 	private boolean isPackageable;
 
 	@NotNull
+	@Min(0)
 	private int stock;
 }

--- a/src/main/java/shop/nuribooks/books/dto/books/BooksRegisterReqDto.java
+++ b/src/main/java/shop/nuribooks/books/dto/books/BooksRegisterReqDto.java
@@ -1,0 +1,57 @@
+package shop.nuribooks.books.dto.books;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class BooksRegisterReqDto {
+	@NotNull
+	private Long stateId;
+
+	@NotNull
+	private Long publisherId;
+
+	@NotNull
+	@Size(min = 1, max = 50)
+	private String title;
+
+	@NotBlank
+	private String thumbnailImageUrl;
+
+	private String detailImageUrl;
+
+	@NotNull
+	private LocalDate publicationDate;
+
+	@NotNull
+	@PositiveOrZero
+	private BigDecimal price;
+
+	@NotNull
+	@PositiveOrZero
+	private int discountRate;
+
+	@NotBlank
+	private String description;
+
+	@NotBlank
+	private String contents;
+
+	@NotBlank
+	private String isbn;
+
+	private boolean isPackageable;
+
+	@NotNull
+	private int stock;
+}

--- a/src/main/java/shop/nuribooks/books/dto/books/BooksRegisterResDto.java
+++ b/src/main/java/shop/nuribooks/books/dto/books/BooksRegisterResDto.java
@@ -2,14 +2,11 @@ package shop.nuribooks.books.dto.books;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@AllArgsConstructor
-@NoArgsConstructor
-@Data
+@Getter
+@Builder
 public class BooksRegisterResDto {
 	private Long id;
 	private Long stateId;

--- a/src/main/java/shop/nuribooks/books/dto/books/BooksRegisterResDto.java
+++ b/src/main/java/shop/nuribooks/books/dto/books/BooksRegisterResDto.java
@@ -1,0 +1,24 @@
+package shop.nuribooks.books.dto.books;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class BooksRegisterResDto {
+	private Long id;
+	private Long stateId;
+	private Long publisherId;
+	private String title;
+	private String thumbnailImageUrl;
+	private LocalDate publicationDate;
+	private BigDecimal price;
+	private int discountRate;
+	private String description;
+	private int stock;
+}

--- a/src/main/java/shop/nuribooks/books/entity/Books.java
+++ b/src/main/java/shop/nuribooks/books/entity/Books.java
@@ -68,6 +68,8 @@ public class Books {
 
 	@ColumnDefault("false")
 	@Column(nullable = false)
+
+	//TODO: Profile 어노테이션을 사용 OR 운영환경 설정 시 mysql 셋팅 후 주석 해제
 	//@Column(nullable = false, columnDefinition = "tinyint(1)")
 	private boolean isPackageable;
 

--- a/src/main/java/shop/nuribooks/books/entity/Books.java
+++ b/src/main/java/shop/nuribooks/books/entity/Books.java
@@ -2,6 +2,7 @@ package shop.nuribooks.books.entity;
 
 import java.math.BigDecimal;
 import java.sql.Date;
+import java.time.LocalDate;
 
 import org.hibernate.annotations.ColumnDefault;
 
@@ -10,6 +11,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -29,6 +32,14 @@ public class Books {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@ManyToOne
+	@JoinColumn(name = "book_state_id", nullable = false)
+	private BookStates stateId;
+
+	@ManyToOne
+	@JoinColumn(name = "publisher_id", nullable = false)
+	private Publishers publisherId;
+
 	@Column(nullable = false, length = 50)
 	private String title;
 
@@ -38,7 +49,7 @@ public class Books {
 	private String detailImageUrl;
 
 	@NotNull
-	private Date publicationDate;
+	private LocalDate publicationDate;
 
 	@NotNull
 	private BigDecimal price;
@@ -56,19 +67,20 @@ public class Books {
 	private String isbn;
 
 	@ColumnDefault("false")
-	@Column(nullable = false, columnDefinition = "tinyint(1)")
+	@Column(nullable = false)
+	//@Column(nullable = false, columnDefinition = "tinyint(1)")
 	private boolean isPackageable;
 
 	@NotNull
-	@ColumnDefault("0")
-	private int likeCount;
+	//@ColumnDefault("0")
+	private int likeCount = 0;
 
 	@NotNull
-	@ColumnDefault("0")
-	private int stock;
+	//@ColumnDefault("0")
+	private int stock = 0;
 
 	@NotNull
-	@ColumnDefault("0")
-	private Long viewCount;
+	//@ColumnDefault("0")
+	private Long viewCount = 0L;
 }
 

--- a/src/main/java/shop/nuribooks/books/entity/Books.java
+++ b/src/main/java/shop/nuribooks/books/entity/Books.java
@@ -1,7 +1,6 @@
 package shop.nuribooks.books.entity;
 
 import java.math.BigDecimal;
-import java.sql.Date;
 import java.time.LocalDate;
 
 import org.hibernate.annotations.ColumnDefault;
@@ -14,8 +13,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,6 +27,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
+@Builder
 @Table(name = "books")
 public class Books {
 
@@ -55,6 +58,8 @@ public class Books {
 	private BigDecimal price;
 
 	@NotNull
+	@Min(0)
+	@Max(100)
 	private int discountRate;
 
 	@NotNull
@@ -66,23 +71,23 @@ public class Books {
 	@Column(nullable = false, length = 20)
 	private String isbn;
 
+	//TODO: Profile 어노테이션을 사용 OR 운영환경 설정 시 mysql 셋팅 후 주석 해제
 	@ColumnDefault("false")
 	@Column(nullable = false)
-
-	//TODO: Profile 어노테이션을 사용 OR 운영환경 설정 시 mysql 셋팅 후 주석 해제
-	//@Column(nullable = false, columnDefinition = "tinyint(1)")
+	//@Column(nullable = false, columnDefinition = "tinyint(1) default 0")
 	private boolean isPackageable;
 
 	@NotNull
 	//@ColumnDefault("0")
-	private int likeCount = 0;
+	private int likeCount;
+
+	@NotNull
+	@Min(0)
+	//@ColumnDefault("0")
+	private int stock;
 
 	@NotNull
 	//@ColumnDefault("0")
-	private int stock = 0;
-
-	@NotNull
-	//@ColumnDefault("0")
-	private Long viewCount = 0L;
+	private Long viewCount;
 }
 

--- a/src/main/java/shop/nuribooks/books/entity/Reviews.java
+++ b/src/main/java/shop/nuribooks/books/entity/Reviews.java
@@ -34,8 +34,9 @@ public class Reviews {
 	private String content;
 
 	@ColumnDefault("0")
-	@Column(nullable = false, columnDefinition = "tinyint(1)")
-	private int score; //평점 1-5점
+	@Column(nullable = false)
+	//@Column(nullable = false, columnDefinition = "tinyint(1)")
+	private byte score; //평점 1-5점
 
 	@NotNull
 	private LocalDateTime createdAt;

--- a/src/main/java/shop/nuribooks/books/entity/Reviews.java
+++ b/src/main/java/shop/nuribooks/books/entity/Reviews.java
@@ -36,7 +36,7 @@ public class Reviews {
 	@ColumnDefault("0")
 	@Column(nullable = false)
 	//@Column(nullable = false, columnDefinition = "tinyint(1)")
-	private byte score; //평점 1-5점
+	private int score; //평점 1-5점
 
 	@NotNull
 	private LocalDateTime createdAt;

--- a/src/main/java/shop/nuribooks/books/exception/DuplicateException.java
+++ b/src/main/java/shop/nuribooks/books/exception/DuplicateException.java
@@ -1,0 +1,7 @@
+package shop.nuribooks.books.exception;
+
+public class DuplicateException extends RuntimeException {
+	public DuplicateException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/shop/nuribooks/books/exception/books/BookStatesIdNotFoundException.java
+++ b/src/main/java/shop/nuribooks/books/exception/books/BookStatesIdNotFoundException.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.exception.books;
+
+import shop.nuribooks.books.exception.ResourceNotFoundException;
+
+public class BookStatesIdNotFoundException extends ResourceNotFoundException {
+	public BookStatesIdNotFoundException(Long id) {
+		super("해당하는 도서상태 ID " + id + " 를 찾을 수 없습니다.");
+	}
+}

--- a/src/main/java/shop/nuribooks/books/exception/books/DuplicateIsbnException.java
+++ b/src/main/java/shop/nuribooks/books/exception/books/DuplicateIsbnException.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.exception.books;
+
+import shop.nuribooks.books.exception.DuplicateException;
+
+public class DuplicateIsbnException extends DuplicateException {
+	public DuplicateIsbnException(String isbn) {
+		super("입력한 isbn " + isbn + " 은 이미 존재합니다.");
+	}
+}

--- a/src/main/java/shop/nuribooks/books/exception/books/PublisherIdNotFoundException.java
+++ b/src/main/java/shop/nuribooks/books/exception/books/PublisherIdNotFoundException.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.exception.books;
+
+import shop.nuribooks.books.exception.ResourceNotFoundException;
+
+public class PublisherIdNotFoundException extends ResourceNotFoundException {
+  public PublisherIdNotFoundException(Long id) {
+    super("해당하는 출판사 ID " + id + " 를 찾을 수 없습니다.");
+  }
+}

--- a/src/main/java/shop/nuribooks/books/repository/books/BookStatesRepository.java
+++ b/src/main/java/shop/nuribooks/books/repository/books/BookStatesRepository.java
@@ -1,0 +1,8 @@
+package shop.nuribooks.books.repository.books;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import shop.nuribooks.books.entity.BookStates;
+
+public interface BookStatesRepository extends JpaRepository<BookStates, Long> {
+}

--- a/src/main/java/shop/nuribooks/books/repository/books/BooksRepository.java
+++ b/src/main/java/shop/nuribooks/books/repository/books/BooksRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import shop.nuribooks.books.entity.Books;
 
 public interface BooksRepository extends JpaRepository<Books, Long> {
+	boolean existsByIsbn(String isbn);
 }

--- a/src/main/java/shop/nuribooks/books/repository/books/BooksRepository.java
+++ b/src/main/java/shop/nuribooks/books/repository/books/BooksRepository.java
@@ -1,0 +1,8 @@
+package shop.nuribooks.books.repository.books;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import shop.nuribooks.books.entity.Books;
+
+public interface BooksRepository extends JpaRepository<Books, Long> {
+}

--- a/src/main/java/shop/nuribooks/books/repository/books/PublishersRepository.java
+++ b/src/main/java/shop/nuribooks/books/repository/books/PublishersRepository.java
@@ -1,0 +1,8 @@
+package shop.nuribooks.books.repository.books;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import shop.nuribooks.books.entity.Publishers;
+
+public interface PublishersRepository extends JpaRepository<Publishers, Long> {
+}

--- a/src/main/java/shop/nuribooks/books/service/books/BooksService.java
+++ b/src/main/java/shop/nuribooks/books/service/books/BooksService.java
@@ -1,0 +1,8 @@
+package shop.nuribooks.books.service.books;
+
+import shop.nuribooks.books.dto.books.BooksRegisterReqDto;
+import shop.nuribooks.books.dto.books.BooksRegisterResDto;
+
+public interface BooksService {
+	BooksRegisterResDto registerBook(BooksRegisterReqDto reqDto);
+}

--- a/src/main/java/shop/nuribooks/books/service/books/impl/BooksServiceImpl.java
+++ b/src/main/java/shop/nuribooks/books/service/books/impl/BooksServiceImpl.java
@@ -1,0 +1,71 @@
+package shop.nuribooks.books.service.books.impl;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import shop.nuribooks.books.dto.books.BooksRegisterReqDto;
+import shop.nuribooks.books.dto.books.BooksRegisterResDto;
+import shop.nuribooks.books.entity.BookStates;
+import shop.nuribooks.books.entity.Books;
+import shop.nuribooks.books.entity.Publishers;
+import shop.nuribooks.books.exception.BadRequestException;
+import shop.nuribooks.books.exception.ResourceNotFoundException;
+import shop.nuribooks.books.repository.books.BookStatesRepository;
+import shop.nuribooks.books.repository.books.BooksRepository;
+import shop.nuribooks.books.repository.books.PublishersRepository;
+import shop.nuribooks.books.service.books.BooksService;
+
+@RequiredArgsConstructor
+@Service
+public class BooksServiceImpl implements BooksService {
+	private final BooksRepository booksRepository;
+	private final BookStatesRepository bookStatesRepository;
+	private final PublishersRepository publishersRepository;
+
+	@Override
+	public BooksRegisterResDto registerBook(BooksRegisterReqDto reqDto) {
+		if(reqDto == null){
+			throw new BadRequestException("요청 본문이 비어있습니다.");
+		}
+
+		BookStates bookState = bookStatesRepository.findById(reqDto.getStateId())
+			.orElseThrow(() -> new ResourceNotFoundException("ID: {stateId}에 해당하는 도서 상태를 찾을 수 없습니다."));
+
+		Publishers publisher = publishersRepository.findById(reqDto.getPublisherId())
+			.orElseThrow(() -> new ResourceNotFoundException("ID: {stateId}에 해당하는 출판사 id를 찾을 수 없습니다."));
+
+		Books books = new Books(
+			null,
+			bookState,
+			publisher,
+			reqDto.getTitle(),
+			reqDto.getThumbnailImageUrl(),
+			reqDto.getDetailImageUrl(),
+			reqDto.getPublicationDate(),
+			reqDto.getPrice(),
+			reqDto.getDiscountRate(),
+			reqDto.getDescription(),
+			reqDto.getContents(),
+			reqDto.getIsbn(),
+			reqDto.isPackageable(),
+			0,
+			reqDto.getStock(),
+			0L
+		);
+
+		booksRepository.save(books);
+
+		return new BooksRegisterResDto(
+			books.getId(),
+			books.getStateId().getId(),
+			books.getPublisherId().getId(),
+			books.getTitle(),
+			books.getThumbnailImageUrl(),
+			books.getPublicationDate(),
+			books.getPrice(),
+			books.getDiscountRate(),
+			books.getDescription(),
+			books.getStock()
+		);
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,15 @@
 spring.application.name=books
+
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:books;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+server.port=8083

--- a/src/test/java/shop/nuribooks/books/controller/BooksControllerTest.java
+++ b/src/test/java/shop/nuribooks/books/controller/BooksControllerTest.java
@@ -1,0 +1,129 @@
+package shop.nuribooks.books.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import shop.nuribooks.books.controller.books.BooksController;
+import shop.nuribooks.books.dto.books.BooksRegisterReqDto;
+import shop.nuribooks.books.dto.books.BooksRegisterResDto;
+import shop.nuribooks.books.exception.BadRequestException;
+import shop.nuribooks.books.exception.ResourceNotFoundException;
+import shop.nuribooks.books.service.books.BooksService;
+
+@WebMvcTest(BooksController.class)
+public class BooksControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private BooksService booksService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	public void registerBooks_ShouldReturnCreated_WhenRequestIsValid() throws Exception {
+		BooksRegisterReqDto reqDto = new BooksRegisterReqDto(
+			1L,
+			1L,
+			"책 제목",
+			"thumbnail.jpg",
+			"detail.jpg",
+			LocalDate.parse("2024-10-21"),
+			BigDecimal.valueOf(10000),
+			0,
+			"책 설명",
+			"책 내용",
+			"1234567890123",
+			true,
+			10
+		);
+
+		BooksRegisterResDto resDto = new BooksRegisterResDto(
+			1L,
+			1L,
+			1L,
+			"책 제목",
+			"thumbnail.jpg",
+			LocalDate.parse("2024-10-21"),
+			BigDecimal.valueOf(10000),
+			0,
+			"책 설명",
+			10);
+
+		when(booksService.registerBook(any(BooksRegisterReqDto.class))).thenReturn(resDto);
+
+		mockMvc.perform(post("/api/books")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(reqDto)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.id").value(1L))
+			.andExpect(jsonPath("$.title").value("책 제목"));
+	}
+
+	@Test
+	public void registerBooks_ShouldReturnBadRequest_WhenRequestIsInvalid() throws Exception {
+		BooksRegisterReqDto reqDto = new BooksRegisterReqDto(
+			null,
+			null,
+			"",
+			null,
+			null,
+			null,
+			null,
+			-1,
+			null,
+			null,
+			null,
+			false,
+			-1
+		);
+
+		when(booksService.registerBook(any(BooksRegisterReqDto.class))).thenThrow(new BadRequestException("잘못된 요청 데이터입니다."));
+
+		mockMvc.perform(post("/api/books")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(reqDto)))
+			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	public void registerBooks_ShouldReturnNotFound_WhenBookStateOrPublisherNotFound() throws Exception {
+		BooksRegisterReqDto reqDto = new BooksRegisterReqDto(
+			9999L,
+			9999L,
+			"책 제목",
+			"thumbnail.jpg",
+			"detail.jpg",
+			LocalDate.now(),
+			BigDecimal.valueOf(10000),
+			0,
+			"책 설명",
+			"책 내용",
+			"1234567890123",
+			true,
+			10
+		);
+
+		when(booksService.registerBook(any(BooksRegisterReqDto.class))).thenThrow(new ResourceNotFoundException("해당 id를 찾지 못했습니다."));
+
+		mockMvc.perform(post("/api/books")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(reqDto)))
+			.andExpect(status().isNotFound());
+	}
+}

--- a/src/test/java/shop/nuribooks/books/controller/BooksControllerTest.java
+++ b/src/test/java/shop/nuribooks/books/controller/BooksControllerTest.java
@@ -53,17 +53,18 @@ public class BooksControllerTest {
 			10
 		);
 
-		BooksRegisterResDto resDto = new BooksRegisterResDto(
-			1L,
-			1L,
-			1L,
-			"책 제목",
-			"thumbnail.jpg",
-			LocalDate.parse("2024-10-21"),
-			BigDecimal.valueOf(10000),
-			0,
-			"책 설명",
-			10);
+		BooksRegisterResDto resDto = BooksRegisterResDto.builder()
+			.id(1L)
+			.stateId(1L)
+			.publisherId(1L)
+			.title("책 제목")
+			.thumbnailImageUrl("thumbnail.jpg")
+			.publicationDate(LocalDate.parse("2024-10-21"))
+			.price(BigDecimal.valueOf(10000))
+			.discountRate(0)
+			.description("책 설명")
+			.stock(10)
+			.build();
 
 		when(booksService.registerBook(any(BooksRegisterReqDto.class))).thenReturn(resDto);
 
@@ -79,7 +80,7 @@ public class BooksControllerTest {
 	public void registerBooks_ShouldReturnBadRequest_WhenRequestIsInvalid() throws Exception {
 		BooksRegisterReqDto reqDto = new BooksRegisterReqDto(
 			null,
-			null,
+			(Long) null,
 			"",
 			null,
 			null,
@@ -93,7 +94,8 @@ public class BooksControllerTest {
 			-1
 		);
 
-		when(booksService.registerBook(any(BooksRegisterReqDto.class))).thenThrow(new BadRequestException("잘못된 요청 데이터입니다."));
+		when(booksService.registerBook(any(BooksRegisterReqDto.class)))
+			.thenThrow(new BadRequestException("잘못된 요청 데이터입니다."));
 
 		mockMvc.perform(post("/api/books")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -119,7 +121,8 @@ public class BooksControllerTest {
 			10
 		);
 
-		when(booksService.registerBook(any(BooksRegisterReqDto.class))).thenThrow(new ResourceNotFoundException("해당 id를 찾지 못했습니다."));
+		when(booksService.registerBook(any(BooksRegisterReqDto.class)))
+			.thenThrow(new ResourceNotFoundException("해당 id를 찾지 못했습니다."));
 
 		mockMvc.perform(post("/api/books")
 				.contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/shop/nuribooks/books/service/BooksServiceImplTest.java
+++ b/src/test/java/shop/nuribooks/books/service/BooksServiceImplTest.java
@@ -1,0 +1,133 @@
+package shop.nuribooks.books.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import shop.nuribooks.books.dto.books.BooksRegisterReqDto;
+import shop.nuribooks.books.dto.books.BooksRegisterResDto;
+import shop.nuribooks.books.entity.BookStates;
+import shop.nuribooks.books.entity.BookStatesEnum;
+import shop.nuribooks.books.entity.Books;
+import shop.nuribooks.books.entity.Publishers;
+import shop.nuribooks.books.exception.BadRequestException;
+import shop.nuribooks.books.exception.ResourceNotFoundException;
+import shop.nuribooks.books.repository.books.BookStatesRepository;
+import shop.nuribooks.books.repository.books.BooksRepository;
+import shop.nuribooks.books.repository.books.PublishersRepository;
+import shop.nuribooks.books.service.books.impl.BooksServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+public class BooksServiceImplTest {
+
+	@InjectMocks
+	private BooksServiceImpl booksService;
+
+	@Mock
+	private BooksRepository booksRepository;
+
+	@Mock
+	private BookStatesRepository bookStatesRepository;
+
+	@Mock
+	private PublishersRepository publishersRepository;
+
+	private BooksRegisterReqDto reqDto;
+
+	private BookStates bookStates;
+
+	@BeforeEach
+	public void setUp() {
+		bookStates = new BookStates(1L, BookStatesEnum.InStock);
+
+		reqDto = new BooksRegisterReqDto(
+			1L,
+			1L,
+			"Book Title",
+			"thumbnail.jpg",
+			"detail.jpg",
+			LocalDate.now(),
+			BigDecimal.valueOf(20000),
+			10,
+			"Book Description",
+			"Book Contents",
+			"1234567890123",
+			true,
+			100
+		);
+	}
+
+	@Test
+	public void registerBook_ShouldReturnResponse_WhenValidRequest() {
+		Publishers mockPublisher = new Publishers(1L, "Publisher Name");
+
+		when(bookStatesRepository.findById(1L)).thenReturn(Optional.of(bookStates));
+		when(publishersRepository.findById(1L)).thenReturn(Optional.of(mockPublisher));
+		when(booksRepository.save(any(Books.class))).thenAnswer(invocation -> {
+			Books book = invocation.getArgument(0);
+			book.setId(1L);
+			return book;
+		});
+
+		BooksRegisterResDto result = booksService.registerBook(reqDto);
+
+		assertNotNull(result);
+		assertEquals(1L, result.getId());
+		assertEquals("Book Title", result.getTitle());
+		verify(booksRepository, times(1)).save(any(Books.class));
+	}
+
+	@Test
+	public void registerBook_ShouldThrowBadRequestException_WhenRequestIsNull() {
+		assertThrows(BadRequestException.class, () -> booksService.registerBook(null));
+	}
+
+	@Test
+	public void registerBook_ShouldThrowResourceNotFoundException_WhenBookStateNotFound() {
+		when(bookStatesRepository.findById(1L)).thenReturn(Optional.empty());
+
+		assertThrows(ResourceNotFoundException.class, () -> booksService.registerBook(reqDto));
+		verify(bookStatesRepository, times(1)).findById(1L);
+	}
+
+	@Test
+	public void registerBook_ShouldThrowResourceNotFoundException_WhenPublisherNotFound() {
+		when(bookStatesRepository.findById(1L)).thenReturn(Optional.of(bookStates));
+		when(publishersRepository.findById(1L)).thenReturn(Optional.empty());
+
+		assertThrows(ResourceNotFoundException.class, () -> booksService.registerBook(reqDto));
+		verify(bookStatesRepository, times(1)).findById(1L);
+		verify(publishersRepository, times(1)).findById(1L);
+	}
+
+	@Test
+	public void registerBook_ShouldSaveBook_WhenBookStateAndPublisherFound() {
+		Publishers mockPublisher = new Publishers(1L, "Publisher Name");
+
+		when(bookStatesRepository.findById(1L)).thenReturn(Optional.of(bookStates));
+		when(publishersRepository.findById(1L)).thenReturn(Optional.of(mockPublisher));
+
+		Books mockBook = new Books(null, bookStates, mockPublisher, "Book Title",
+			"thumbnail.jpg", "detail.jpg", LocalDate.now(), BigDecimal.valueOf(20000),
+			10, "Book Description", "Book Contents", "1234567890123",
+			true, 0, 100, 0L);
+
+		when(booksRepository.save(any(Books.class))).thenReturn(mockBook);
+
+		BooksRegisterResDto result = booksService.registerBook(reqDto);
+
+		assertNotNull(result);
+		assertEquals("Book Title", result.getTitle());
+		verify(booksRepository, times(1)).save(any(Books.class));
+	}
+}


### PR DESCRIPTION
1. 도서 등록 기능 추가
2. H2 데이터베이스와의 호환성을 고려한 수정 
    - tinyint(1) 타입의 컬럼과 기본값 설정으로 인한 에러발생
    -> 엔티티에 존재하는 columnDefinition 및 ColumnDefault 삭제

Closes #1 
