### PR TITLE
Feature/order shipping payment 주문에 관련된 entity, service interface 추가

### DIFF
--- a/src/main/java/shop/nuribooks/books/order/order/entity/Order.java
+++ b/src/main/java/shop/nuribooks/books/order/order/entity/Order.java
@@ -1,0 +1,86 @@
+package shop.nuribooks.books.order.order.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.hibernate.annotations.Comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+import shop.nuribooks.books.member.customer.entity.Customer;
+
+/**
+ * 주문 Entity
+ *
+ * @author nuri
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "orders")
+@Comment("주문")
+public class Order {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Comment("주문 아이디")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "customer_id", nullable = false,
+		foreignKey = @ForeignKey(name = "FK_orders_to_customers_1"))
+	@Comment("주문자 정보")
+	private Customer customer;
+
+	@Column(precision = 9, nullable = false)
+	@Comment("결제 금액")
+	private BigDecimal paymentPrice;
+
+	@Column(nullable = false)
+	@Comment("주문 일시")
+	private LocalDateTime orderedAt;
+
+	@Column(precision = 9, nullable = false)
+	@Comment("포장비")
+	private BigDecimal wrappingPrice = BigDecimal.ZERO;
+
+	@Comment("예상 배송 날짜")
+	private LocalDate expectedDeliveryAt;
+
+	/**
+	 * 주문 생성자 (builder)
+	 *
+	 * @param customer 주문자 정보
+	 * @param paymentPrice 결제 가격
+	 * @param orderedAt 주문 일시
+	 * @param wrappingPrice 포장 비용
+	 * @param expectedDeliveryAt 예상 배송 날짜
+	 */
+	@Builder
+	public Order(Customer customer,
+		BigDecimal paymentPrice,
+		LocalDateTime orderedAt,
+		BigDecimal wrappingPrice,
+		LocalDate expectedDeliveryAt) {
+		this.customer = customer;
+		this.paymentPrice = paymentPrice;
+		this.orderedAt = orderedAt;
+		this.wrappingPrice = wrappingPrice != null ? wrappingPrice : BigDecimal.ZERO;
+		this.expectedDeliveryAt = expectedDeliveryAt;
+	}
+
+}

--- a/src/main/java/shop/nuribooks/books/order/order/service/OrderService.java
+++ b/src/main/java/shop/nuribooks/books/order/order/service/OrderService.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.order.order.service;
+
+/**
+ * 주문 서비스 인터페이스
+ *
+ * @author nuri
+ */
+public interface OrderService {
+}

--- a/src/main/java/shop/nuribooks/books/order/orderDetail/entity/OrderDetail.java
+++ b/src/main/java/shop/nuribooks/books/order/orderDetail/entity/OrderDetail.java
@@ -1,0 +1,93 @@
+package shop.nuribooks.books.order.orderDetail.entity;
+
+import java.math.BigDecimal;
+
+import org.hibernate.annotations.Comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+import shop.nuribooks.books.book.book.entity.Book;
+import shop.nuribooks.books.order.order.entity.Order;
+
+/**
+ * 주문 상세 Entity
+ *
+ * @author nuri
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "order_details")
+@Comment("주문 상세 정보")
+public class OrderDetail {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Comment("주문 상세 아이디")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "order_id", nullable = false,
+		foreignKey = @ForeignKey(name = "FK_order_details_to_orders_1"))
+	@Comment("연결된 주문 정보")
+	private Order order;
+
+	@Column(nullable = false)
+	@Comment("주문 상태")
+	private OrderState orderState = OrderState.PENDING;
+
+	@ManyToOne
+	@JoinColumn(name = "book_id", nullable = false,
+		foreignKey = @ForeignKey(name = "FK_order_details_to_books_1"))
+	@Comment("연결된 책 정보")
+	private Book book;
+
+	@Column(nullable = false)
+	@Comment("주문 수량")
+	private int count = 1;
+
+	@Column(precision = 9, nullable = false)
+	@Comment("단가")
+	private BigDecimal unitPrice;
+
+	@Column(nullable = false)
+	@Comment("포장 여부")
+	private Boolean isWrapped = false;
+
+	/**
+	 * 주문 상세 생성자 (Builder)
+	 *
+	 * @param order 주문 정보
+	 * @param orderState 주문 상태
+	 * @param book 상품(책) 정보
+	 * @param count 상품 수량
+	 * @param unitPrice 개별 가격
+	 * @param isWrapped 포장 여부
+	 */
+	@Builder
+	public OrderDetail(Order order,
+		OrderState orderState,
+		Book book,
+		int count,
+		BigDecimal unitPrice,
+		Boolean isWrapped) {
+		this.order = order;
+		this.orderState = orderState;
+		this.book = book;
+		this.count = count;
+		this.unitPrice = unitPrice;
+		this.isWrapped = isWrapped != null ? isWrapped : false;
+	}
+}

--- a/src/main/java/shop/nuribooks/books/order/orderDetail/entity/OrderState.java
+++ b/src/main/java/shop/nuribooks/books/order/orderDetail/entity/OrderState.java
@@ -1,0 +1,56 @@
+package shop.nuribooks.books.order.orderDetail.entity;
+
+/**
+ * 주문 상태 Enum
+ *
+ * <ul>
+ *     <li><b>PENDING</b>: 주문 대기 상태 (주문이 생성된 상태, 결제 전)</li>
+ *     <li><b>PAID</b>: 결제 완료 상태</li>
+ *     <li><b>DELIVERING</b>: 배송 중 상태</li>
+ *     <li><b>COMPLETED</b>: 주문 완료 상태 (배송 완료 후)</li>
+ *     <li><b>RETURNED</b>: 반품 상태</li>
+ *     <li><b>CANCELED</b>: 결제 취소 상태</li>
+ * </ul>
+ *
+ * @author nuri
+ */
+public enum OrderState {
+	PENDING(1,"주문 대기"),
+	PAID(2,"결제 완료"), // 결제가 실패했을 때를 대비한 상태
+	DELIVERING(3,"배송중"),
+	COMPLETED(4,"주문 완료"),
+	RETURNED(5,"반품"),
+	CANCELED(6,"결제 취소");
+
+	private final int code;
+	private final String korName;
+
+	/**
+	 * 주문 상태 생성자
+	 *
+	 * @param code 주문 상세 코드
+	 * @param korName 주문 상태의 한국어 이름
+	 */
+	OrderState(int code, String korName) {
+		this.code = code;
+		this.korName = korName;
+	}
+
+	/**
+	 * 주문 상태의 코드 값을 반환
+	 *
+	 * @return 주문 상태 코드
+	 */
+	public int getCode() {
+		return code;
+	}
+
+	/**
+	 * 주문 상태의 한국어 이름을 반환
+	 *
+	 * @return 주문 상태의 한국어 이름
+	 */
+	public String getKorName() {return korName;}
+
+
+}

--- a/src/main/java/shop/nuribooks/books/order/orderDetail/service/OrderDetailService.java
+++ b/src/main/java/shop/nuribooks/books/order/orderDetail/service/OrderDetailService.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.order.orderDetail.service;
+
+/**
+ * 주문 상세 서비스 인터페이스
+ *
+ * @author nuri
+ */
+public interface OrderDetailService {
+}

--- a/src/main/java/shop/nuribooks/books/order/shipping/entity/Shipping.java
+++ b/src/main/java/shop/nuribooks/books/order/shipping/entity/Shipping.java
@@ -1,0 +1,130 @@
+package shop.nuribooks.books.order.shipping.entity;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.Comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+import shop.nuribooks.books.order.order.entity.Order;
+
+/**
+ * 배송지 entity
+ *
+ * @author nuri
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "shippings")
+@Comment("배송 정보")
+public class Shipping {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Comment("배송 아이디")
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name = "order_id", nullable = false,
+		foreignKey = @ForeignKey(name = "FK_shippings_to_orders_1"))
+	@Comment("연관된 주문 정보")
+	private Order order;
+
+	@ManyToOne
+	@JoinColumn(name = "shipping_policy_id", nullable = false,
+		foreignKey = @ForeignKey(name = "FK_shippings_to_shipping_policies_1"))
+	@Comment("배송 정책 정보")
+	private ShippingPolicy shippingPolicy;
+
+	@Column(length = 50, nullable = false)
+	@Comment("받는 사람 이름")
+	@NotBlank
+	private String recipientName;
+
+	@Column(length = 100, nullable = false)
+	@Comment("받는 사람 주소")
+	@NotBlank
+	private String recipientAddress;
+
+	@Column(length = 50, nullable = false)
+	@Comment("받는 사람 상세 주소")
+	@NotBlank
+	private String recipientAddressDetail;
+
+	@Column(length = 50, nullable = false)
+	@Comment("받는 사람 우편 번호")
+	@NotBlank
+	private String recipientZipcode;
+
+	@Column(length = 11, nullable = false)
+	@Comment("받는 사람 연락처")
+	@NotBlank
+	private String recipientPhoneNumber;
+
+	@Column(length = 50, nullable = false)
+	@Comment("보내는 사람 이름")
+	@NotBlank
+	private String senderName;
+
+	@Column(length = 11, nullable = false)
+	@Comment("보내는 사람 전화번호")
+	@NotBlank
+	private String senderPhoneNumber;
+
+	@Comment("출고일")
+	private LocalDateTime shippingAt;
+
+	@Column(length = 15)
+	@Comment("주문 송장 번호")
+	private String orderInvoiceNumber;
+
+	@Comment("배송 완료 일시")
+	private LocalDateTime shippingCompletedAt;
+
+	/**
+	 * 배송지 생성자 (builder)
+	 *
+	 * @param order 주문 정보
+	 * @param shippingPolicy 배송 정책 (배송비)
+	 * @param recipientName 받는 사람 이름
+	 * @param recipientAddress 받는 사람 주소
+	 * @param recipientAddressDetail 받는 사람 상세 주소
+	 * @param recipientZipcode 받는 사람 우편번호
+	 * @param recipientPhoneNumber 받는 사람 연락처
+	 * @param senderName 보내는 사람 이름
+	 * @param senderPhoneNumber 보내는 사람 연락처
+	 * @param shippingAt 출고일
+	 * @param orderInvoiceNumber 주문 송장 번호
+	 * @param shippingCompletedAt 배송 완료 일시
+	 */
+	@Builder
+	public Shipping(Order order, ShippingPolicy shippingPolicy, String recipientName, String recipientAddress,
+		String recipientAddressDetail, String recipientZipcode, String recipientPhoneNumber, String senderName,
+		String senderPhoneNumber, LocalDateTime shippingAt, String orderInvoiceNumber,
+		LocalDateTime shippingCompletedAt) {
+		this.order = order;
+		this.shippingPolicy = shippingPolicy;
+		this.recipientName = recipientName;
+		this.recipientAddress = recipientAddress;
+		this.recipientAddressDetail = recipientAddressDetail;
+		this.recipientZipcode = recipientZipcode;
+		this.recipientPhoneNumber = recipientPhoneNumber;
+		this.senderName = senderName;
+		this.senderPhoneNumber = senderPhoneNumber;
+	}
+}

--- a/src/main/java/shop/nuribooks/books/order/shipping/entity/ShippingPolicy.java
+++ b/src/main/java/shop/nuribooks/books/order/shipping/entity/ShippingPolicy.java
@@ -1,0 +1,58 @@
+package shop.nuribooks.books.order.shipping.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.Comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+/**
+ * 배송비 정책 entity
+ *
+ * @author nuri
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "shipping_policies")
+@Comment("배송비 정책")
+public class ShippingPolicy {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Comment("배송비 정책 ID")
+	private Long id;
+
+	@Column(nullable = false)
+	@Comment("배송비")
+	private int shippingFee;
+
+	@Column(nullable = false)
+	@Comment("적용 날짜")
+	private LocalDateTime appliedDatetime;
+
+	@Column(nullable = false)
+	@Comment("최소 주문 금액")
+	private BigDecimal minimumOrderPrice;
+
+	/**
+	 * 배송비 정책 생성자 (Builder)
+	 *
+	 * @param shippingFee 배송비
+	 * @param appliedDatetime 적용 날짜
+	 * @param minimumOrderPrice 최소 주문 금액
+	 */
+	@Builder
+	public ShippingPolicy(int shippingFee, LocalDateTime appliedDatetime, BigDecimal minimumOrderPrice) {
+		this.shippingFee = shippingFee;
+		this.appliedDatetime = appliedDatetime;
+		this.minimumOrderPrice = minimumOrderPrice;
+	}
+}

--- a/src/main/java/shop/nuribooks/books/order/shipping/service/ShippingPolicyService.java
+++ b/src/main/java/shop/nuribooks/books/order/shipping/service/ShippingPolicyService.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.order.shipping.service;
+
+/**
+ * 배송지 정책 서비스 인터페이스
+ *
+ * @author nuri
+ */
+public interface ShippingPolicyService {
+}

--- a/src/main/java/shop/nuribooks/books/order/shipping/service/ShippingService.java
+++ b/src/main/java/shop/nuribooks/books/order/shipping/service/ShippingService.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.order.shipping.service;
+
+/**
+ * 배송지 서비스 인터페이스
+ *
+ * @author nuri
+ */
+public interface ShippingService {
+}

--- a/src/main/java/shop/nuribooks/books/order/wrapping/Service/WrappingPaperService.java
+++ b/src/main/java/shop/nuribooks/books/order/wrapping/Service/WrappingPaperService.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.order.wrapping.Service;
+
+/**
+ * 포장지 서비스 인터페이스
+ *
+ * @author nuri
+ */
+public interface WrappingPaperService {
+}

--- a/src/main/java/shop/nuribooks/books/order/wrapping/Service/WrappingService.java
+++ b/src/main/java/shop/nuribooks/books/order/wrapping/Service/WrappingService.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.order.wrapping.Service;
+
+/**
+ * 주문에 대한 포장 정보 서비스 인터페이스
+ *
+ * @author nuri
+ */
+public interface WrappingService {
+}

--- a/src/main/java/shop/nuribooks/books/order/wrapping/entity/Wrapping.java
+++ b/src/main/java/shop/nuribooks/books/order/wrapping/entity/Wrapping.java
@@ -1,0 +1,55 @@
+package shop.nuribooks.books.order.wrapping.entity;
+
+import org.hibernate.annotations.Comment;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import shop.nuribooks.books.order.order.entity.Order;
+
+/**
+ * 주문에 대한 포장 정보" entity
+ *
+ * @author nuri
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "wrappings")
+@Comment("주문에 대한 포장 정보")
+public class Wrapping {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Comment("포장 아이디")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "order_id", nullable = false,
+	foreignKey = @ForeignKey(name = "FK_orders_TO_wrappings_1"))
+	@Comment("연결된 주문 정보")
+	private Order order;
+
+	@ManyToOne
+	@JoinColumn(name = "wrapping_paper_id", nullable = false,
+		foreignKey = @ForeignKey(name = "FK_wrapping_papers_TO_wrappings_1"))
+	@Comment("연결된 포장지 정보")
+	private WrappingPaper wrappingPaper;
+
+	/**
+	 * 포장 생성자 (Builder)
+	 *
+	 * @param order 주문 정보
+	 * @param wrappingPaper 포장지 정보
+	 */
+	public Wrapping(Order order, WrappingPaper wrappingPaper) {
+		this.order = order;
+		this.wrappingPaper = wrappingPaper;
+	}
+}

--- a/src/main/java/shop/nuribooks/books/order/wrapping/entity/WrappingPaper.java
+++ b/src/main/java/shop/nuribooks/books/order/wrapping/entity/WrappingPaper.java
@@ -1,0 +1,59 @@
+package shop.nuribooks.books.order.wrapping.entity;
+
+import java.math.BigDecimal;
+
+import org.hibernate.annotations.Comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * 포장지 entity
+ *
+ * @author nuri
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "wrapping_papers")
+@Comment("포장지 정보")
+public class WrappingPaper {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Comment("포장지 아이디")
+	private Long id;
+
+	@Column(length = 100, nullable = false)
+	@NotBlank
+	@Comment("제목")
+	private String title;
+
+	@Column(nullable = false)
+	@NotBlank
+	@Comment("이미지 경로")
+	private String imageUrl;
+
+	@Column(precision = 9, nullable = false)
+	@Comment("포장 비용")
+	private BigDecimal wrappingPrice = BigDecimal.ZERO;
+
+	/**
+	 * 포장지 생성자 (Builder)
+	 *
+	 * @param title 포장지 제목
+	 * @param imageUrl 이미지 경로
+	 * @param wrappingPrice 포장 비용
+	 */
+	public WrappingPaper(String title, String imageUrl, BigDecimal wrappingPrice) {
+		this.title = title;
+		this.imageUrl = imageUrl;
+		this.wrappingPrice = wrappingPrice;
+	}
+}

--- a/src/main/java/shop/nuribooks/books/payment/payment/entity/Payment.java
+++ b/src/main/java/shop/nuribooks/books/payment/payment/entity/Payment.java
@@ -1,0 +1,66 @@
+package shop.nuribooks.books.payment.payment.entity;
+
+import org.hibernate.annotations.Comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.nuribooks.books.order.order.entity.Order;
+
+/**
+ * 결제 정보 entity
+ *
+ * @author nuri
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Comment("결제 정보")
+@Table(name = "payments")
+public class Payment {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Comment("결제 아이디")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "payment_method_id", nullable = false,
+	foreignKey =  @ForeignKey(name = "FK_payments_to_payment_methods_1)"))
+	@Comment("연결된 결제 수단 정보")
+	private PaymentMethod paymentMethod;
+
+	@OneToOne
+	@JoinColumn(name = "order_id", nullable = false,
+		foreignKey = @ForeignKey(name = "FK_payments_to_orders_1"))
+	@Comment("연결된 주문 정보")
+	private Order order;
+
+
+	@Column(nullable = false)
+	@Comment("결제 상태")
+	private PaymentState paymentState = PaymentState.PENDING;
+
+	/**
+	 * 결제 정보 생성자 (Builder)
+	 *
+	 * @param paymentMethod 결제 수단
+	 * @param order 주문 정보
+	 * @param paymentState 결제 상태
+	 */
+	public Payment(PaymentMethod paymentMethod, Order order, PaymentState paymentState) {
+		this.paymentMethod = paymentMethod;
+		this.order = order;
+		this.paymentState = paymentState;
+	}
+}

--- a/src/main/java/shop/nuribooks/books/payment/payment/entity/PaymentMethod.java
+++ b/src/main/java/shop/nuribooks/books/payment/payment/entity/PaymentMethod.java
@@ -1,0 +1,44 @@
+package shop.nuribooks.books.payment.payment.entity;
+
+import org.hibernate.annotations.Comment;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * 결제 수단 정보 entity
+ *
+ * @author nuri
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "payment_methods")
+@Comment("결제 수단 정보")
+public class PaymentMethod {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Comment("결제 수단 아이디")
+	private Long id;
+
+	@Column(nullable = false)
+	@Comment("결제 수단 명")
+	@NotBlank
+	private String name;
+
+	/**
+	 * 결제 수단 생성자 (Builder)
+	 *
+	 * @param name 결제 수단 명
+	 */
+	public PaymentMethod(String name) {
+		this.name = name;
+	}
+}

--- a/src/main/java/shop/nuribooks/books/payment/payment/entity/PaymentState.java
+++ b/src/main/java/shop/nuribooks/books/payment/payment/entity/PaymentState.java
@@ -1,0 +1,44 @@
+package shop.nuribooks.books.payment.payment.entity;
+
+/**
+ * 결제 상태 Enum
+ * <ul>
+ *     <li><b>PENDING</b>: 결제 대기 상태 (사용자가 결제를 시작했으나 아직 완료되지 않음)</li>
+ *     <li><b>COMPLETED</b>: 결제 완료 상태 (결제가 성공적으로 이루어진 상태)</li>
+ *     <li><b>CANCELED</b>: 결제 취소 상태 (결제가 취소된 상태)</li>
+ * </ul>
+ *
+ * @author nuri
+ */
+public enum PaymentState {
+	PENDING(1, "결제 대기"),
+	COMPLETED(2, "결제 완료"),
+	CANCELED(3, "결제 취소");
+
+	private final int code;
+	private final String korName;
+
+	/**
+	 * 결제 상태 생성자
+	 * @param code 결제 상태 코드
+	 * @param korName 결제 상태의 한국어 이름
+	 */
+	PaymentState(int code, String korName) {
+		this.code = code;
+		this.korName = korName;
+	}
+
+	/**
+	 * 결제 상태의 코드 값 반환
+	 * @return 결제 상태의 코드
+	 */
+	public int getCode() {
+		return code;
+	}
+
+	/**
+	 * 결제 상태의 한국어 이름을 반환
+	 * @return 결제 상태의 한국어 이름
+	 */
+	public String getKorName() {return korName;}
+}

--- a/src/main/java/shop/nuribooks/books/payment/payment/service/PaymentMethodService.java
+++ b/src/main/java/shop/nuribooks/books/payment/payment/service/PaymentMethodService.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.payment.payment.service;
+
+/**
+ * 결제 수단 서비스 인터페이스
+ *
+ * @author nuri
+ */
+public interface PaymentMethodService {
+}

--- a/src/main/java/shop/nuribooks/books/payment/payment/service/PaymentService.java
+++ b/src/main/java/shop/nuribooks/books/payment/payment/service/PaymentService.java
@@ -1,0 +1,9 @@
+package shop.nuribooks.books.payment.payment.service;
+
+/**
+ * 결제 서비스 인터페이스
+ *
+ * @author nuri
+ */
+public interface PaymentService {
+}

--- a/src/test/java/shop/nuribooks/books/order/order/entity/OrderTest.java
+++ b/src/test/java/shop/nuribooks/books/order/order/entity/OrderTest.java
@@ -1,0 +1,72 @@
+package shop.nuribooks.books.order.order.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import shop.nuribooks.books.member.customer.entity.Customer;
+
+class OrderTest {
+
+	@Test
+	@DisplayName("주문 생성 테스트")
+	void testOrderBuilder() {
+
+		Customer customer = Customer.builder()
+			.name("정누리")
+			.password("Passw@rd1")
+			.phoneNumber("01012345678")
+			.email("nuri1234@example.com")
+			.build();
+
+		BigDecimal paymentPrice = new BigDecimal("50000");
+		LocalDateTime orderedAt = LocalDateTime.of(2024, 11, 10, 14, 30);
+		BigDecimal wrappingPrice = new BigDecimal("2000");
+		LocalDate expectedDeliveryAt = LocalDate.of(2024, 11, 11);
+
+		Order order = Order.builder()
+			.customer(customer)
+			.paymentPrice(paymentPrice)
+			.orderedAt(orderedAt)
+			.wrappingPrice(wrappingPrice)
+			.expectedDeliveryAt(expectedDeliveryAt)
+			.build();
+
+		assertNotNull(customer);
+		assertEquals(paymentPrice, order.getPaymentPrice());
+		assertEquals(orderedAt, order.getOrderedAt());
+		assertEquals(wrappingPrice, order.getWrappingPrice());
+		assertEquals(expectedDeliveryAt, order.getExpectedDeliveryAt());
+	}
+
+	@Test
+	@DisplayName("포장 값의 기본값이 0가 되는 지 테스트")
+	void testWrappingPriceDefaultValue() {
+		Customer customer = Customer.builder()
+			.name("정누리")
+			.password("Passw@rd1")
+			.phoneNumber("01012345678")
+			.email("nuri1234@example.com")
+			.build();
+
+		BigDecimal paymentPrice = new BigDecimal("50000");
+		LocalDateTime orderedAt = LocalDateTime.of(2024, 11, 10, 14, 30);
+		LocalDate expectedDeliveryAt = LocalDate.of(2024, 11, 11);
+
+		Order order = Order.builder()
+			.customer(customer)
+			.paymentPrice(paymentPrice)
+			.orderedAt(orderedAt)
+			.expectedDeliveryAt(expectedDeliveryAt)
+			.build();
+
+		assertNotNull(order.getWrappingPrice());
+		assertEquals(BigDecimal.ZERO, order.getWrappingPrice());
+	}
+
+}


### PR DESCRIPTION

### 설명
 - 주문/결제와 관련 있는 엔티티를 미리 구조만 추가했습니다.
 - 후속 작업은 연관있는 엔티티 마다 브랜치를 나누어 작업할 예정입니다.

### 기본 엔티티 추가
- 주문 관련 엔티티 기본 구조 추가
  -  (`Order`, `OrderDetail`, `Shipping`, `ShippingPolicy`, `Wrapping`, `WrappingPaper`, `Payment`, `PaymentMethod`)  
- 각 엔티티에 필요한 필드 및 기본 생성자/빌더 패턴 구현