### PR TITLE
Refactor/admin coupon view

### DIFF
--- a/src/main/java/shop/nuribooks/books/book/coupon/controller/CouponController.java
+++ b/src/main/java/shop/nuribooks/books/book/coupon/controller/CouponController.java
@@ -66,7 +66,7 @@ public class CouponController {
 	})
 	@HasRole(role = AuthorityType.ADMIN)
 	@GetMapping("/list")
-	public ResponseEntity<Page<CouponResponse>> getAllCoupons(Pageable pageable) {
+	public ResponseEntity<Page<CouponResponse>> getCoupons(Pageable pageable) {
 		Page<CouponResponse> couponPolicyResponses = couponService.getAllCoupons(pageable);
 		return ResponseEntity.status(HttpStatus.OK).body(couponPolicyResponses);
 	}

--- a/src/main/java/shop/nuribooks/books/book/coupon/controller/CouponController.java
+++ b/src/main/java/shop/nuribooks/books/book/coupon/controller/CouponController.java
@@ -53,9 +53,7 @@ public class CouponController {
 	})
 	@HasRole(role = AuthorityType.ADMIN)
 	@GetMapping
-	public ResponseEntity<Page<CouponResponse>> getCoupons(
-		@RequestParam(value = "type", defaultValue = "MIXED") CouponType type,
-		Pageable pageable) {
+	public ResponseEntity<Page<CouponResponse>> getCoupons(@RequestParam CouponType type, Pageable pageable) {
 		Page<CouponResponse> couponPolicyResponses = couponService.getCoupons(type, pageable);
 		return ResponseEntity.status(HttpStatus.OK).body(couponPolicyResponses);
 	}

--- a/src/main/java/shop/nuribooks/books/book/coupon/controller/CouponController.java
+++ b/src/main/java/shop/nuribooks/books/book/coupon/controller/CouponController.java
@@ -46,7 +46,7 @@ public class CouponController {
 			.body(new ResponseMessage(HttpStatus.CREATED.value(), "쿠폰 생성 성공"));
 	}
 
-	@Operation(summary = "쿠폰 목록 조회", description = "쿠폰 목록을 조회합니다.")
+	@Operation(summary = "쿠폰 타입별 목록 조회", description = "쿠폰 타입별 목록을 조회합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "조회 성공"),
 		@ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
@@ -54,9 +54,22 @@ public class CouponController {
 	@HasRole(role = AuthorityType.ADMIN)
 	@GetMapping
 	public ResponseEntity<Page<CouponResponse>> getCoupons(
-		@RequestParam(value = "type", defaultValue = "ALL") CouponType type,
+		@RequestParam(value = "type", defaultValue = "MIXED") CouponType type,
 		Pageable pageable) {
 		Page<CouponResponse> couponPolicyResponses = couponService.getCoupons(type, pageable);
+		return ResponseEntity.status(HttpStatus.OK).body(couponPolicyResponses);
+	}
+
+
+	@Operation(summary = "쿠폰 전체 목록 조회", description = "쿠폰 전체 목록을 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "조회 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+	})
+	@HasRole(role = AuthorityType.ADMIN)
+	@GetMapping("/list")
+	public ResponseEntity<Page<CouponResponse>> getAllCoupons(Pageable pageable) {
+		Page<CouponResponse> couponPolicyResponses = couponService.getAllCoupons(pageable);
 		return ResponseEntity.status(HttpStatus.OK).body(couponPolicyResponses);
 	}
 

--- a/src/main/java/shop/nuribooks/books/book/coupon/service/CouponService.java
+++ b/src/main/java/shop/nuribooks/books/book/coupon/service/CouponService.java
@@ -14,6 +14,8 @@ public interface CouponService {
 
 	Page<CouponResponse> getCoupons(CouponType type, Pageable pageable);
 
+	Page<CouponResponse> getAllCoupons(Pageable pageable);
+
 	CouponResponse getCouponById(Long id);
 
 	void expireCoupon(Long id);

--- a/src/main/java/shop/nuribooks/books/book/coupon/service/CouponServiceImpl.java
+++ b/src/main/java/shop/nuribooks/books/book/coupon/service/CouponServiceImpl.java
@@ -1,12 +1,6 @@
 package shop.nuribooks.books.book.coupon.service;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -63,14 +57,8 @@ public class CouponServiceImpl implements CouponService {
 	 */
 	@Override
 	public Page<CouponResponse> getAllCoupons(Pageable pageable) {
-		List<CouponResponse> combinedCoupons = Stream.of(CouponType.ALL, CouponType.BOOK, CouponType.CATEGORY)
-			.flatMap(type -> getCoupons(type, pageable).getContent().stream())
-			.sorted(Comparator.comparingLong(CouponResponse::id))
-			.collect(Collectors.toList());
-
-		int start = Math.min((int)pageable.getOffset(), combinedCoupons.size());
-		int end = Math.min(start + pageable.getPageSize(), combinedCoupons.size());
-		return new PageImpl<>(combinedCoupons.subList(start, end), pageable, combinedCoupons.size());
+		Page<Coupon> coupons = couponRepository.findAll(pageable);
+		return coupons.map(CouponResponse::of);
 	}
 
 	/**


### PR DESCRIPTION
관리자 페이지에서 쿠폰 조회시 쿠폰 타입별(도서, 카테고리, 전체쿠폰)로 조회할 수 있고, 모든 쿠폰 한번에 조회할 수 있습니다!
쿠폰 목록 페이지가 너무 복잡해서 쿠폰 상세 조회 페이지를 추가했습니다! (땡스투 용택배송기사님)

쿠폰 엔티티 수정이 끝나면 <발급수량여부, 발급가능수량> 추가 할 계획입니다!!

<img width="1188" alt="스크린샷 2024-11-29 오전 12 56 11" src="https://github.com/user-attachments/assets/2a4189d1-dcad-433a-8660-52e1513bd871">
<img width="729" alt="스크린샷 2024-11-29 오전 12 56 37" src="https://github.com/user-attachments/assets/71d5dde8-32ba-4927-b786-e4700cb9610f">
